### PR TITLE
Make TZID-validation ical-object-order independent (WIP)

### DIFF
--- a/libkcaldav.h
+++ b/libkcaldav.h
@@ -287,6 +287,19 @@ struct	icaltime {
 };
 
 /*
+ * rfc5545 does not specify ordering of components. It is possible to
+ * encounter date-time properties with Time-Zone-Identifiers (TZID)
+ * before the according VTIMEZONE-component has been parsed.
+ * This structure keeps track of these icaltime-objects.
+ *
+ */
+struct icaltime_incomplete {
+	const struct icalnode *np;
+	struct icaltime *tm;
+	struct icaltime_incomplete *next;
+};
+
+/*
  * An iCalendar component.
  * Each of these may be associated with component properties such as the
  * UID or DTSTART, which are referenced here.


### PR DESCRIPTION
It seems like RFC 5545 does not specify an order for ical-components. It is therefore possible to encounter properties with TZID options for which the corresponding VTIMEZONE was not parsed yet.

At the moment, the validation takes place while parsing the property containing the TZID option (``ical_tzdatetime()``)  and fails if the corresponding VTIMEZONE was not parsed before.

This PR keeps a list of elements missing their corresponding VTIMEZONE and validates after all components were parsed. I am not sure if this is the right way to solve this, another way I can think of would be parsing the whole object twice, just saving the timezone-components on the first run.

The following is a simple ical-file which fails to parse without the change:

> BEGIN:VCALENDAR
> VERSION:2.0
> PRODID:-//Example Corp.//CalDAV Client//EN
> BEGIN:VEVENT
> DTSTAMP:20060206T001102Z
> DTSTART;TZID=US/Eastern:20060102T100000
> DURATION:PT1H
> SUMMARY:Event #1
> Description:Go Steelers!
> UID:74855313FA803DA593CD579A@example.com
> END:VEVENT
> BEGIN:VTIMEZONE
> LAST-MODIFIED:20040110T032845Z
> TZID:US/Eastern
> BEGIN:DAYLIGHT
> DTSTART:20000404T020000
> RRULE:FREQ=YEARLY;BYDAY=1SU;BYMONTH=4
> TZNAME:EDT
> TZOFFSETFROM:-0500
> TZOFFSETTO:-0400
> END:DAYLIGHT
> BEGIN:STANDARD
> DTSTART:20001026T020000
> RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10
> TZNAME:EST
> TZOFFSETFROM:-0400
> TZOFFSETTO:-0500
> END:STANDARD
> END:VTIMEZONE
> END:VCALENDAR