### PR TITLE
allow KREQU_IF_MATCH-value to be surrounded by quotes

### DIFF
--- a/put.c
+++ b/put.c
@@ -90,7 +90,12 @@ method_put(struct kreq *r)
 			ical_free(p);
 			return;
 		}
-		digest = buf;
+		if ('"' == buf[0] && sz >= 3 && '"' == buf[sz - 1]) {
+			buf[sz - 1] = '\0';
+			digest = buf + 1;
+		} else {
+			digest = buf;
+		}
 	} else if (NULL != r->reqmap[KREQU_IF]) {
 		sz = strlcpy(buf, 
 			r->reqmap[KREQU_IF]->val,


### PR DESCRIPTION
Per [rfc7232#section-3.1](https://tools.ietf.org/html/rfc7232#section-3.1) the If-Match Header-value may be surrounded by double quotes. As of now, kcaldav will erroneously return ``403 Forbidden`` on PUT and DELETE, if the value is in quotation marks [(log-file, DAVx^5 - Android)](https://gist.github.com/mk-f/4d3aeb54a65203db8b80cfffb85f3991).